### PR TITLE
Fix test_simple_linux to resolve segmentation fault

### DIFF
--- a/runtime/nb_runtime.h
+++ b/runtime/nb_runtime.h
@@ -66,12 +66,10 @@ void nb__ipc_deinit();
 void nb__mlx5_init(const char* name);
 
 
-/*
 char* nb__request_send_buffer(void);
 void* nb__return_send_buffer(char*);
 void nb__linux_runtime_init(const char* iface);
 void nb__linux_runtime_deinit(void);
-*/
 
 // Generated protocol API
 void nb__run_ingress_step (void*, int);

--- a/test/test_simple_linux/client.c
+++ b/test/test_simple_linux/client.c
@@ -25,14 +25,14 @@ int main(int argc, char* argv[]) {
 	nb__linux_runtime_init("dummy0");
 	printf("Linux Runtime initialized\n");
 
-	nb__net_init();
-
 	unsigned long long server_id_i = 0;
 	unsigned long long client_id_i = 0;
 	memcpy(&server_id_i, server_id, sizeof(server_id));
 	memcpy(&client_id_i, client_id, sizeof(client_id));
 
 	nb__my_host_id = client_id_i;
+
+	nb__net_init();
 
 	nb__connection_t * conn = nb__establish(server_id_i, 8080, 8081, callback);
 	

--- a/test/test_simple_linux/server.c
+++ b/test/test_simple_linux/server.c
@@ -23,7 +23,6 @@ static void callback(int event, nb__connection_t * c) {
 int main(int argc, char* argv[]) {
 	nb__linux_runtime_init("dummy0");
 	printf("Linux Runtime initialized\n");
-	nb__net_init();
 
 	unsigned long long server_id_i = 0;
 	unsigned long long client_id_i = 0;
@@ -31,6 +30,8 @@ int main(int argc, char* argv[]) {
 	memcpy(&client_id_i, client_id, sizeof(client_id));
 
 	nb__my_host_id = server_id_i;
+
+	nb__net_init();
 
 	nb__connection_t * conn = nb__establish(client_id_i, 8081, 8080, callback);
 


### PR DESCRIPTION
## Problem
The `test_simple_linux` build was failing with a segmentation fault.
I ran this command and got the result.
```cmd
# make simple_test_linux
./build/test/simple_linux_server &
./build/test/simple_linux_client
cc -O3 -fno-strict-aliasing -c /home/hoku/repo/net-blocks/test/test_simple_linux/server.c -o /home/hoku/repo/net-blocks/build/test/simple_test_linux/server.o -I/home/hoku/repo/net-blocks/runtime -I/home/hoku/repo/net-blocks/scratch
cc -O3 -fno-strict-aliasing -c /home/hoku/repo/net-blocks/test/test_simple_linux/client.c -o /home/hoku/repo/net-blocks/build/test/simple_test_linux/client.o -I/home/hoku/repo/net-blocks/runtime -I/home/hoku/repo/net-blocks/scratch
cc -O3 -fno-strict-aliasing -c /home/hoku/repo/net-blocks/runtime/nb_linux_transport.c -o /home/hoku/repo/net-blocks/build/runtime/nb_linux_transport.o -I /home/hoku/repo/net-blocks/runtime -I /home/hoku/repo/net-blocks/scratch
cc /home/hoku/repo/net-blocks/build/runtime/nb_runtime_simple.o /home/hoku/repo/net-blocks/build/runtime/nb_simple.o /home/hoku/repo/net-blocks/build/runtime/nb_timer.o /home/hoku/repo/net-blocks/build/test/simple_test_linux/server.o /home/hoku/repo/net-blocks/build/runtime/nb_linux_transport.o -o /home/hoku/repo/net-blocks/build/test/simple_linux_server
cc /home/hoku/repo/net-blocks/build/runtime/nb_runtime_simple.o /home/hoku/repo/net-blocks/build/runtime/nb_simple.o /home/hoku/repo/net-blocks/build/runtime/nb_timer.o /home/hoku/repo/net-blocks/build/test/simple_test_linux/client.o /home/hoku/repo/net-blocks/build/runtime/nb_linux_transport.o -o /home/hoku/repo/net-blocks/build/test/simple_linux_client
[1] 1432091
Linux Runtime initialized
Linux Runtime initialized
Segmentation fault (core dumped)
```

## Solution
I modified the initialization sequence to ensure `nb__my_host_id` is set before calling `nb__net_init`.
After fixing the code, I got this result.
```cmd
Linux Runtime initialized
Linux Runtime initialized
Received = Hello from client
Received = Hello from server
```